### PR TITLE
Add ipykernel to Sphinx requirements

### DIFF
--- a/sphinx_requirements.txt
+++ b/sphinx_requirements.txt
@@ -1,2 +1,3 @@
 nbsphinx
 recommonmark
+ipykernel


### PR DESCRIPTION
I'm not sure whether this is sufficient, but with a bit of luck, this will lead to a working syntax highlighting in code cells.

See also https://nbsphinx.readthedocs.io/en/latest/installation.html#Pygments-Lexer-for-Syntax-Highlighting.