### PR TITLE
Don't set an explicit pygments_style

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -93,7 +93,7 @@ exclude_patterns = [
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+#pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False


### PR DESCRIPTION
This removes the ugly greenish background from code cells.