### PR TITLE
Fix Routh Table for Polynomials with Even Polynomial Factors

### DIFF
--- a/tbcontrol/symbolic.py
+++ b/tbcontrol/symbolic.py
@@ -1,7 +1,7 @@
 """Control functions which operate symbolically using sympy"""
 
 import sympy
-
+import numpy
 
 def linearise(expr, variables, bars=None):
     """Linearise a nonlinear expression
@@ -53,6 +53,15 @@ def routh(p):
         for j in range(N//2):
             S = M[[i-2, i-1], [0, j+1]]
             M[i, j] = sympy.simplify(-S.det()/M[i-1,0])
+        # If a row of the routh table becomes zero,Take the derivative of the previous row and substitute it instead
+        # Ref: Norman S. Nise, Control Systems Engineering, 8th Edition, Chapter 6, Section 3
+        if M[i,:] == sympy.Matrix([[0]*(M.shape[1])]):
+            #Find the coefficients on taking the derivative
+            diff_arr = numpy.arange(N-i, -0.1, -2, dtype=int)
+            diff_arr.resize(M.shape[1])
+            diff_arr = sympy.Matrix(numpy.asarray([diff_arr]))
+            #Multiply the coefficients with the value in previous row
+            M[i,:] = sympy.matrix_multiply_elementwise(diff_arr,M[i-1,:])
     return M[:, :-1]
 
 


### PR DESCRIPTION
If an even polynomial is a factor of the original polynomial, Routh table produces a row of zeros. This commit uses the method described in Norman S. Nise, Control Systems Engineering, 8th Edition, Chapter 6, Section 3 to handle this edge case.

Examples:
```python
import sympy
s = sympy.Symbol('s')
p = sympy.Poly([1,1,12,22,39,59,48,38,20],s)
routh(p)
p = sympy.Poly([1,3,10,24,48,96,128,192,128],s)
routh(p)
p = sympy.Poly([1,3,30,30,200],s)
routh(p)
```
The Routh table for the above polynomials now works properly